### PR TITLE
Fix: Container Running with Dangerous Root Access Permissions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+
+# Create a non-root user
+RUN groupadd -r appuser && useradd -r -g appuser -d /home/appuser -s /sbin/nologin -c "Docker image user" appuser
+
+# Create home directory and set ownership
+RUN mkdir -p /home/appuser && chown -R appuser:appuser /home/appuser
+
+# Switch to non-root user
+USER appuser


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** By not specifying a USER, a program in the container may run as 'root'. This is a security hazard. If an attacker can control a process running as root, they may have control over the container. Ensure that the last USER in a Dockerfile is a USER other than 'root'.
- **Rule ID:** dockerfile.security.missing-user.missing-user-Dockerfile
- **Severity:** MEDIUM
- **File:** Dockerfile
- **Lines Affected:** 22 - 22

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `Dockerfile` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.