### PR TITLE
Fix: AWS Access Key Found Directly in Code in new_keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,6 @@ Thumbs.db
 *.pdf
 
 # Frontend
-node_modules
+node_modulesnew_keys
+credentials
+.aws/

--- a/README.md
+++ b/README.md
@@ -248,3 +248,35 @@ If you have a feature request, please open an [issue](https://github.com/virattt
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
+
+## AWS Credentials Setup
+
+This project requires AWS credentials to function properly. **Never commit actual credentials to version control.**
+
+### Setup Options:
+
+1. **Environment Variables (Recommended for development):**
+   ```bash
+   export AWS_ACCESS_KEY_ID=your_access_key_here
+   export AWS_SECRET_ACCESS_KEY=your_secret_key_here
+   ```
+
+2. **AWS Credentials File:**
+   ```bash
+   aws configure
+   ```
+   Or manually create `~/.aws/credentials`:
+   ```
+   [default]
+   aws_access_key_id = your_access_key_here
+   aws_secret_access_key = your_secret_key_here
+   ```
+
+3. **IAM Roles (Recommended for production):**
+   Use IAM roles when running on AWS infrastructure (EC2, ECS, Lambda, etc.)
+
+### Security Notes:
+- Never commit credentials to version control
+- Use IAM roles with minimal required permissions
+- Rotate credentials regularly
+- Consider using AWS Secrets Manager for production environments

--- a/new_keys
+++ b/new_keys
@@ -1,5 +1,0 @@
-[default]
-aws_access_key_id = AKIAQYLPMN5HHHFPZAM2
-aws_secret_access_key = 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
-output = json
-region = us-east-2

--- a/new_keys.template
+++ b/new_keys.template
@@ -1,0 +1,16 @@
+# AWS Credentials Template
+# DO NOT put actual credentials in this file or commit them to version control
+
+# Option 1: Use environment variables
+# export AWS_ACCESS_KEY_ID=your_access_key_here
+# export AWS_SECRET_ACCESS_KEY=your_secret_key_here
+
+# Option 2: Use AWS credentials file
+# Configure using: aws configure
+# Or manually create ~/.aws/credentials with:
+# [default]
+# aws_access_key_id = your_access_key_here
+# aws_secret_access_key = your_secret_key_here
+
+# Option 3: Use IAM roles (recommended for EC2/ECS/Lambda)
+# No credentials needed - AWS handles authentication automatically


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** AWS Access Key ID Value detected. This is a sensitive credential and should not be hardcoded here. Instead, read this value from an environment variable or keep it in a separate, private file.
- **Rule ID:** generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
- **Severity:** HIGH
- **File:** new_keys
- **Lines Affected:** 2 - 2

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `new_keys` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.